### PR TITLE
get filename from file obj instead of input field

### DIFF
--- a/src/services/BasketService.js
+++ b/src/services/BasketService.js
@@ -228,7 +228,7 @@
 
             var match = $input[0].name.match( /^ParamValueFile\[(\d+)]\[(\d+)]$/ );
 
-            return addOrderParamValue( articleWithParams, match[1], match[2], $input.val() );
+            return addOrderParamValue( articleWithParams, match[1], match[2], orderParamUploadFiles[key][0]['name'] );
         }
 
         /**


### PR DESCRIPTION
due to security reasons some browsers (e.g. Chrome, IE) are not allowing to get the value of a file input and replace it with [C:\Fakepath](http://martinivanov.net/2009/06/09/the-mystery-of-cfakepath-unveiled/)

@m8n 